### PR TITLE
Update validate-action.yml

### DIFF
--- a/.github/workflows/validate-action.yml
+++ b/.github/workflows/validate-action.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:  
     - name: Setup conda
-    - uses: iiasa/actions/setup-conda@main
+      uses: iiasa/actions/setup-conda@main
       with:
         conda_type: ${{ matrix.conda }}
         


### PR DESCRIPTION
This PR fixes the following error message from the first GHA run [here](https://github.com/iiasa/actions/actions/runs/1435237856)

```
Error : .github#L1
every step must define a `uses` or `run` key
```
