### PR TITLE
Use same PyPI repo for RCs and releases

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,18 +1,23 @@
-name: Build package / publish
+name: Build package and publish
 
 on:
   workflow_call:
     inputs:
       python-version:
         description: |-
-           Python version for the workflow, passed to actions/setup-python.
+          Python version for the workflow, passed to actions/setup-python.
         type: string
         required: false
         default: "3.x"
+      repository-url:
+        description: |-
+          Repository URL for twine. Use https://test.pypi.org/ for testing.
+        type: string
+        required: false
+        # NB this default value copied from twine/repository.py
+        default: https://upload.pypi.org/
     secrets:
       PYPI_TOKEN:
-        required: true
-      TESTPYPI_TOKEN:
         required: true
 
 jobs:
@@ -43,18 +48,11 @@ jobs:
         twine check dist/*
 
     # Performed on a new tag
-    - name: Publish to TestPyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
-      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
-      with:
-        user: __token__
-        password: ${{ secrets.TESTPYPI_TOKEN }}
-        repository-url: https://test.pypi.org/legacy/
-
     # Performed on a release event
-    - name: Publish to PyPI
+    - name: Publish to ${{ inputs.repository-url }}
       uses: pypa/gh-action-pypi-publish@release/v1
-      if: github.event_name == 'release'
+      if: github.event_name == 'release' || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags'))
       with:
         user: __token__
         password: ${{ secrets.PYPI_TOKEN }}
+        repository-url: ${{ inputs.repository-url }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Editors, IDEs
+.vscode

--- a/README.rst
+++ b/README.rst
@@ -57,27 +57,29 @@ Lint and check Python code with black, flake8, isort, and mypy.
 ``publish.yaml``
 ----------------
 
-Build Python package distributions; check with ``twine``, and publish to (Test)PyPI.
+Build Python package distributions, check with ``twine``, and publish to (Test)PyPI.
 
 - `Source <https://github.com/iiasa/actions/blob/main/.github/workflows/publish.yaml>`__
 - Usage example:
 
   .. code-block:: yaml
 
-     name: Build package / publish
+     name: Build package and publish
 
      on:
        pull_request:
          branches: [ main ]  # Package is built and checked
        push:
          branches: [ main ]  # Package is built and checked
-         tags: [ "v*" ]  # Package is pushed to TestPyPI
+         tags: [ "v*" ]  # Package is published to PyPI
        release:
-         types: [ published ]  # Package is also pushed to PyPI
+         types: [ published ]  # Package is also published to PyPI
 
      jobs:
        publish:
          uses: iiasa/actions/.github/workflows/publish.yaml@main
          secrets:
            PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-           TESTPYPI_TOKEN: ${{ secrets.TESTPYPI_TOKEN }}
+         # Publish to TestPyPI; omit with: to publish to PyPI itself
+         with:
+           repository-url: https://test.pypi.org/


### PR DESCRIPTION
This avoids some awkward outcomes of the current behaviour:
- Repos using this PR have a series of RCs on TestPyPI, and a series of actual releases on PyPI, but not vice versa.
- Developers must give extra options to `pip install` to install the RCs (from TestPI) with their dependencies, which may not be on TestPyPI at all.

As a result of this change, the `TESTPYPI_TOKEN` secret becomes redundant; the same `PYPI_TOKEN` is used regardless of target, with the `repository-url:` parameter controlling where it is employed.