### PR TITLE
Update setup-gams

### DIFF
--- a/setup-gams/action.yml
+++ b/setup-gams/action.yml
@@ -24,8 +24,7 @@ runs:
     env:
       RUNNER_OS: ${{ runner.os }}
       GAMS_VERSION: ${{ inputs.version }}
-      GHA_PATH: ${{ github.action_path }}
-    run: ${GITHUB_ACTION_PATH}/script.sh
+    run: ${{ github.action_path }}/script.sh
     shell: bash
 
   - name: Set up GAMS license

--- a/setup-gams/action.yml
+++ b/setup-gams/action.yml
@@ -24,7 +24,7 @@ runs:
     env:
       RUNNER_OS: ${{ runner.os }}
       GAMS_VERSION: ${{ inputs.version }}
-    run: ${{ github.action_path }}/script.sh
+    run: ${GITHUB_ACTION_PATH}/script.sh
     shell: bash
 
   - name: Set up GAMS license

--- a/setup-gams/script.sh
+++ b/setup-gams/script.sh
@@ -54,7 +54,7 @@ ls -al
 if [ $GAMS_OS = "windows" ]; then
   # Write a PowerShell script. Install to the same directory as *nix unzip
   cat << EOF >install-gams.ps1
-Start-Process "gams.exe" "/SP-", "/SILENT", "/DIR=$GITHUB_ACTION_PATH\\gams", "/NORESTART" -Wait
+Start-Process "gams.exe" "/SP-", "/SILENT", "/DIR=$GITHUB_ACTION_PATH\\$DEST", "/NORESTART" -Wait
 EOF
   cat install-gams.ps1
 
@@ -64,6 +64,8 @@ else
   # Extract files
   unzip -q gams.exe
 fi
+
+ls -al
 
 # Return to the last directory
 popd

--- a/setup-gams/script.sh
+++ b/setup-gams/script.sh
@@ -45,10 +45,9 @@ if [ -x gams.exe ]; then
   TIME_CONDITION=--remote-time --time-cond gams.exe
 fi
 
-curl $URL --output gams.exe $TIME_CONDITION --trace trace.txt
-cat trace.txt
+curl $URL --output gams.exe $TIME_CONDITION -v
 
-ls -al
+ls -al "/usr/ssl/certs/"
 
 # TODO confirm checksum
 

--- a/setup-gams/script.sh
+++ b/setup-gams/script.sh
@@ -56,6 +56,8 @@ printenv | grep "ssl/certs"
 echo $URL
 echo $TIME_CONDITION
 
+curl --version
+
 curl --output gams.exe $TIME_CONDITION -v $URL
 
 # TODO confirm checksum

--- a/setup-gams/script.sh
+++ b/setup-gams/script.sh
@@ -10,24 +10,25 @@ BASE=$(realpath gams)
 # GAMS source URL fragment, and path fragment for extracted files
 case $RUNNER_OS in
   Linux)
-    CACHE_PATH="$GITHUB_ACTION_PATH/gams.exe"
     GAMS_OS=linux
     FRAGMENT=${GAMS_OS}_x64_64_sfx
     ;;
   macOS)
-    CACHE_PATH="$GITHUB_ACTION_PATH/gams.exe"
     GAMS_OS=macosx
     FRAGMENT=osx_x64_64_sfx
     ;;
   Windows)
-    CACHE_PATH="$GHA_PATH\\gams.exe"
     GAMS_OS=windows
     FRAGMENT=${GAMS_OS}_x64_64
     ;;
 esac
 
+CACHE_PATH="$GITHUB_ACTION_PATH/gams.exe"
+
 # Path fragment for extraction or install
 DEST=gams$(echo $GAMS_VERSION | cut -d. -f1-2)_$FRAGMENT
+
+ls -a
 
 # Write to special GitHub Actions environment variable to update $PATH for
 # subsequent workflow steps
@@ -48,12 +49,14 @@ fi
 
 curl --silent $URL --output gams.exe $TIME_CONDITION
 
+ls -a
+
 # TODO confirm checksum
 
 if [ $GAMS_OS = "windows" ]; then
   # Write a PowerShell script. Install to the same directory as *nix unzip
   cat << EOF >install-gams.ps1
-Start-Process "gams.exe" "/SP-", "/SILENT", "/DIR=$GHA_PATH\\$DEST", "/NORESTART" -Wait
+Start-Process "gams.exe" "/SP-", "/DIR=$GITHUB_ACTION_PATH\\$DEST", "/NORESTART" -Wait
 EOF
   cat install-gams.ps1
 

--- a/setup-gams/script.sh
+++ b/setup-gams/script.sh
@@ -28,11 +28,9 @@ CACHE_PATH="$GITHUB_ACTION_PATH/gams.exe"
 # Path fragment for extraction or install
 DEST=gams$(echo $GAMS_VERSION | cut -d. -f1-2)_$FRAGMENT
 
-ls -a
-
 # Write to special GitHub Actions environment variable to update $PATH for
 # subsequent workflow steps
-echo "$GITHUB_ACTION_PATH/$DEST" >> $GITHUB_PATH
+echo "$BASE" >> $GITHUB_PATH
 
 # Set the "steps.{id}.outputs.cache-patch" value for use with actions/cache
 echo "cache-path=$CACHE_PATH" >> $GITHUB_OUTPUT
@@ -47,16 +45,17 @@ if [ -x gams.exe ]; then
   TIME_CONDITION=--remote-time --time-cond gams.exe
 fi
 
+cd gams
 curl --silent $URL --output gams.exe $TIME_CONDITION
 
-ls -a
+ls -al
 
 # TODO confirm checksum
 
 if [ $GAMS_OS = "windows" ]; then
   # Write a PowerShell script. Install to the same directory as *nix unzip
   cat << EOF >install-gams.ps1
-Start-Process "gams.exe" "/SP-", "/DIR=$GITHUB_ACTION_PATH\\$DEST", "/NORESTART" -Wait
+Start-Process "gams.exe" "/SP-", "/SILENT", "/DIR=$GITHUB_ACTION_PATH\\gams", "/NORESTART" -Wait
 EOF
   cat install-gams.ps1
 

--- a/setup-gams/script.sh
+++ b/setup-gams/script.sh
@@ -48,6 +48,9 @@ fi
 curl $URL --output gams.exe $TIME_CONDITION -v
 
 ls -al "/usr/ssl/certs/"
+curl-config --ca
+
+printenv | grep "ssl/certs"
 
 # TODO confirm checksum
 

--- a/setup-gams/script.sh
+++ b/setup-gams/script.sh
@@ -53,7 +53,10 @@ curl-config --ca
 echo "printenv"
 printenv | grep "ssl/certs"
 
-curl $URL --output gams.exe $TIME_CONDITION -v
+echo $URL
+echo $TIME_CONDITION
+
+curl --output gams.exe $TIME_CONDITION -v $URL
 
 # TODO confirm checksum
 

--- a/setup-gams/script.sh
+++ b/setup-gams/script.sh
@@ -47,7 +47,7 @@ fi
 
 curl $URL --output gams.exe $TIME_CONDITION
 
-ls -al $GITHUB_ACTION_PATH/$DEST
+ls -al
 
 # TODO confirm checksum
 

--- a/setup-gams/script.sh
+++ b/setup-gams/script.sh
@@ -45,19 +45,6 @@ if [ -x gams.exe ]; then
   TIME_CONDITION=--remote-time --time-cond gams.exe
 fi
 
-ls -al "/usr/ssl/certs/"
-
-echo "curl-config:"
-curl-config --ca
-
-echo "printenv"
-printenv | grep "ssl/certs"
-
-echo $URL
-echo $TIME_CONDITION
-
-curl --version
-
 curl --output gams.exe $TIME_CONDITION -v $URL
 
 # TODO confirm checksum

--- a/setup-gams/script.sh
+++ b/setup-gams/script.sh
@@ -45,7 +45,7 @@ if [ -x gams.exe ]; then
   TIME_CONDITION=--remote-time --time-cond gams.exe
 fi
 
-curl $URL --output gams.exe $TIME_CONDITION
+curl $URL --output gams.exe $TIME_CONDITION -v
 
 ls -al
 
@@ -64,8 +64,6 @@ else
   # Extract files
   unzip -q gams.exe
 fi
-
-ls -al
 
 # Return to the last directory
 popd

--- a/setup-gams/script.sh
+++ b/setup-gams/script.sh
@@ -30,7 +30,7 @@ DEST=gams$(echo $GAMS_VERSION | cut -d. -f1-2)_$FRAGMENT
 
 # Write to special GitHub Actions environment variable to update $PATH for
 # subsequent workflow steps
-echo "$BASE" >> $GITHUB_PATH
+echo "$GITHUB_ACTION_PATH/$DEST" >> $GITHUB_PATH
 
 # Set the "steps.{id}.outputs.cache-patch" value for use with actions/cache
 echo "cache-path=$CACHE_PATH" >> $GITHUB_OUTPUT
@@ -45,10 +45,9 @@ if [ -x gams.exe ]; then
   TIME_CONDITION=--remote-time --time-cond gams.exe
 fi
 
-cd gams
-curl --silent $URL --output gams.exe $TIME_CONDITION
+curl $URL --output gams.exe $TIME_CONDITION
 
-ls -al
+ls -al $GITHUB_ACTION_PATH/$DEST
 
 # TODO confirm checksum
 

--- a/setup-gams/script.sh
+++ b/setup-gams/script.sh
@@ -45,7 +45,8 @@ if [ -x gams.exe ]; then
   TIME_CONDITION=--remote-time --time-cond gams.exe
 fi
 
-curl $URL --output gams.exe $TIME_CONDITION -v
+curl $URL --output gams.exe $TIME_CONDITION --trace trace.txt
+cat trace.txt
 
 ls -al
 

--- a/setup-gams/script.sh
+++ b/setup-gams/script.sh
@@ -45,7 +45,7 @@ if [ -x gams.exe ]; then
   TIME_CONDITION=--remote-time --time-cond gams.exe
 fi
 
-curl --output gams.exe $TIME_CONDITION -v $URL
+curl --output gams.exe $TIME_CONDITION $URL
 
 # TODO confirm checksum
 

--- a/setup-gams/script.sh
+++ b/setup-gams/script.sh
@@ -45,12 +45,15 @@ if [ -x gams.exe ]; then
   TIME_CONDITION=--remote-time --time-cond gams.exe
 fi
 
-curl $URL --output gams.exe $TIME_CONDITION -v
-
 ls -al "/usr/ssl/certs/"
+
+echo "curl-config:"
 curl-config --ca
 
+echo "printenv"
 printenv | grep "ssl/certs"
+
+curl $URL --output gams.exe $TIME_CONDITION -v
 
 # TODO confirm checksum
 


### PR DESCRIPTION
This PR merges the branch that was used to debug the recent CI failures for setup-gams on message_ix. It mainly removes the `GHA_PATH` environment variable in favor of the existing `GITHUB_ACTION_PATH`. It also removes the `--silent` option from curl, which doesn't seem necessary.

Merging this will allow https://github.com/iiasa/message_ix/pull/790 to receive a commit that makes it use the `main` version of this action again. The commits can definitely be squashed.