### PR TITLE
Run Windows PowerShell step even when restoring a cache

### DIFF
--- a/setup-gams/script.py
+++ b/setup-gams/script.py
@@ -78,7 +78,12 @@ if __name__ == "__main__":
         or install_dir.joinpath("gams.exe").is_file()
     ):
         pass  # Already exists, e.g. restored from cache → skip install
-    elif uname.system == "Windows":
+    else:
+        # Extract files (in the current working directory)
+        run(["unzip", "-q", str(dl_path)])
+
+    # Complete the setup on Windows
+    if uname.system == "Windows":
         # Write and invoke a PowerShell script that invokes the installer
         script_path = Path("setup-gams.ps1")
         script_path.write_text(
@@ -86,9 +91,6 @@ if __name__ == "__main__":
             '"/NORESTART" -Wait'
         )
         run(["pwsh", str(script_path)])
-    else:
-        # Extract files (in the current working directory)
-        run(["unzip", "-q", str(dl_path)])
 
     # Install license
     license = os.environ.pop("GAMS_LICENSE")


### PR DESCRIPTION
For https://github.com/iiasa/ixmp/pull/552, I introduced `gamsapi` to the ixmp ecosystem. This is looking for Windows in a specific way, i.e. with this function when setting up an empty `Container` like we do in the test suite:

```python
        if _is_win:
            if system_directory is None:
                self._system_directory = GamsWorkspace._find_gams_win()
                if not self._system_directory or not os.path.exists(
                    os.path.join(os.path.abspath(self._system_directory), "optgams.def")
                ):
                    raise GamsException(
                        "GAMS System directory "
                        + self._system_directory
                        + " not found or invalid. Either specify a valid system directory by passing it to the GamsWorkspace constructor or run findthisgams.exe in the GAMS system directory you want to use."
                    )

    def _find_gams_win():
        gams_dir = ""
        if sys.version_info[0] >= 3:
            import winreg as wreg
        else:
            import _winreg as wreg

        try:
            gams_dir = wreg.QueryValue(
                wreg.HKEY_CURRENT_USER, r"Software\Classes\gams.location"
            )
        except:
            try:
                gams_dir = wreg.QueryValue(
                    wreg.HKEY_LOCAL_MACHINE, r"Software\Classes\gams.location"
                )
            except:
                pass
        return gams_dir
```

This is somehow incompatible with how we currently use `setup-gams`. In particular, when restoring gams from a cache on Windows, the above functions raise the above error message about being unable to find gams (as described [here](https://github.com/iiasa/ixmp/pull/552#issuecomment-2820908257)). 
I haven't tried in detail to add debug output and see whether `self._system_directory` should be fine and just `optgams.def` is missing from what we cache because at first glance, we include the directory in our cache that contains the file on my local machine (if `D:\a\_actions\iiasa\actions\main\setup-gams\gams48.1_windows_x64_64` can be translated to my Ubuntu machine as expected). 

Instead, the changes proposed here run the install script on Windows even when restoring from a Cache, which makes gams findable by `gamsapi`. 
This has the downside that the step is quite slow, but looking into how this can be made faster could be worthwhile on its own and might deserve its own issue. 
