### PR TITLE
Add use-cache input to setup-gams

### DIFF
--- a/.github/workflows/setup-gams.yaml
+++ b/.github/workflows/setup-gams.yaml
@@ -21,6 +21,9 @@ jobs:
         - 25.1.1
         - 43.4.1
         - 48.6.1
+        use-cache:
+        - true
+        - false
 
         exclude:
         # No arm64 distribution for this version
@@ -40,6 +43,7 @@ jobs:
       uses: ./setup-gams
       with:
         version: ${{ matrix.version }}
+        use-cache: ${{ matrix.use-cache }}
 
     - name: Confirm GAMS is on PATH & license is recognized
       run: gams

--- a/.github/workflows/setup-gams.yaml
+++ b/.github/workflows/setup-gams.yaml
@@ -20,6 +20,7 @@ jobs:
         version:
         - 25.1.1
         - 43.4.1
+        - 48.6.1
 
         exclude:
         # No arm64 distribution for this version

--- a/.github/workflows/setup-gams.yaml
+++ b/.github/workflows/setup-gams.yaml
@@ -18,9 +18,8 @@ jobs:
         - ubuntu-latest
         - windows-latest
         version:
-        - 25.1.1
-        - 43.4.1
         - 48.6.1
+        - 50.1.0
         use-cache:
         - true
         - false

--- a/setup-gams/README.md
+++ b/setup-gams/README.md
@@ -10,4 +10,6 @@ steps:
     version: 25.1.1
     # Content for gamslice.txt, e.g. from a repository secret
     license: ${{ secrets.GAMS_LICENSE }}
+    # True to save and restore cache
+    use-cache: true
 ```

--- a/setup-gams/action.yml
+++ b/setup-gams/action.yml
@@ -10,6 +10,10 @@ inputs:
     description: "Version of GAMS to install"
     required: false
     default: "25.1.1"
+  use-cache:
+    description: "True to save and restore cache"
+    required: false
+    default: true
 
 runs:
   using: composite
@@ -21,6 +25,7 @@ runs:
 
   - name: Restore cache, if any
     id: restore-cache
+    if: inputs.use-cache
     uses: actions/cache/restore@v4
     with:
       path: |
@@ -40,7 +45,7 @@ runs:
   #   shell: bash
 
   - name: Cache GAMS distribution and installed files
-    if: "! ${{ steps.restore-cache.outputs.cache-hit }}"
+    if: "${{ inputs.use-cache }} && ! ${{ steps.restore-cache.outputs.cache-hit }}"
     uses: actions/cache/save@v4
     with:
       path: |


### PR DESCRIPTION
On self-hosted runners, restoring the cache is very slow; for example [here](https://github.com/iiasa/message_data/actions/runs/15819822809/job/44586299517#step:10:52), taking 8–10 minutes.

While on Windows runners the cache step is faster than installing, on Linux it can sometimes be faster to simply download and re-install GAMS.

This PR adds an input that allows to disable the cache restore/save steps.

**Also:**
- Adjust the matrix for the "setup-gams" workflow in this repo, that tests the action.
  - Previously, this installed GAMS versions **25.1.1** and **43.4.1**. It appears neither of these versions is provided by GAMS Corp. anymore; instead an HTTP 403 Access Denied message is returned.
  - https://www.gams.com/download/ lists versions from 50 (the current) back to 46.
  - The links to download pages for versions 46 and 47 also give HTTP 403 Access Denied.
  - So, the workflow is updated to test versions **48.6.1** and **50.1.0**.