### PR TITLE
Adjust handling of use-cache input to setup-gams action

### DIFF
--- a/.github/workflows/setup-gams.yaml
+++ b/.github/workflows/setup-gams.yaml
@@ -32,7 +32,7 @@ jobs:
       fail-fast: false
 
     runs-on: ${{ matrix.os }}
-    name: ${{ matrix.os }}-${{ matrix.version }}
+    name: ${{ matrix.os }}-${{ matrix.version }}-cache-${{ matrix.use-cache }}
 
     steps:
     - name: Check out repository

--- a/setup-gams/action.yml
+++ b/setup-gams/action.yml
@@ -13,7 +13,7 @@ inputs:
   use-cache:
     description: "True to save and restore cache"
     required: false
-    default: true
+    default: "true"
 
 runs:
   using: composite
@@ -25,7 +25,7 @@ runs:
 
   - name: Restore cache, if any
     id: restore-cache
-    if: inputs.use-cache
+    if: fromJSON(inputs.use-cache)
     uses: actions/cache/restore@v4
     with:
       path: |
@@ -45,7 +45,7 @@ runs:
   #   shell: bash
 
   - name: Cache GAMS distribution and installed files
-    if: "${{ inputs.use-cache }} && ! ${{ steps.restore-cache.outputs.cache-hit }}"
+    if: fromJSON(inputs.use-cache) && !steps.restore-cache.outputs.cache-hit
     uses: actions/cache/save@v4
     with:
       path: |


### PR DESCRIPTION
I merged #16 with too much haste. It turns out (see [here](https://github.com/iiasa/actions/actions/runs/15820520013/job/44588506857#step:3:11)) that even with "use-cache: false" the cache steps are still being run; see [here](https://github.com/iiasa/actions/actions/runs/15820520013/job/44588506857#step:3:28).

This PR adjusts.